### PR TITLE
fixed conversions api call bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import registerServiceWorker from './registerServiceWorker';
 render(
   <Provider store={store}>
     <Router>
-      <Route path="/:filter?" component={App} />
+      <Route path="/text_to_speech_fe/:filter?" component={App} />
     </Router>
   </Provider>,
   document.getElementById("app")

--- a/src/js/components/LoginForm.js
+++ b/src/js/components/LoginForm.js
@@ -5,16 +5,12 @@ import { addUserData } from "../actions/index";
 import { login } from "../actions/index";
 import { AxiosRequest } from "../helpers/axios";
 import { RequestError } from "../helpers/error_handling";
-import { addUserConversion } from "../actions/index";
-import { addUserSpeechConversion } from "../actions/index";
 import { addFormError } from "../actions/index";
 
 const mapDispatchToProps = dispatch => {
   return {
     addUserData: userData => dispatch(addUserData(userData)),
     login: loggedIn => dispatch(login(loggedIn)),
-    addUserConversion: userConversion => dispatch(addUserConversion(userConversion)),
-    addUserSpeechConversion: userSpeechConversion => dispatch(addUserSpeechConversion(userSpeechConversion)),
     addFormError: formError => dispatch(addFormError(formError))
   };
 };

--- a/src/js/components/UserPage.js
+++ b/src/js/components/UserPage.js
@@ -10,7 +10,9 @@ import { addUserSpeechConversion } from "../actions/index";
 const mapStateToProps = state => {
   return{
     speechToText: state.speechToText,
-    userData: state.userData
+    userData: state.userData,
+    conversions: state.conversions,
+    speech_conversions: state.speech_conversions,
   };
 };
 
@@ -28,7 +30,13 @@ class ConnectedUserPage extends Component{
   }
 
   componentDidMount(){
-    this.getConversions();
+    this.props.conversions.length === 0
+    ? this.getConversions()
+    : null
+
+    this.props.speech_conversions.length === 0
+    ? this.getSpeechConversions()
+    : null
   }
 
   getConversions(){
@@ -45,7 +53,6 @@ class ConnectedUserPage extends Component{
       response => {
         const conversions = response.data
         this.props.addUserConversion(conversions);
-        this.getSpeechConversions();
       }
     ).catch((error) => {
       RequestError(error)


### PR DESCRIPTION
speech and text conversions were doubling in the redux conversions state when changing routes by going to user profile and then back to conversions

added logic in userPage to only make api call if redux conversions store is empty whether tts or stt

ready for deploy